### PR TITLE
[IPFS upload Fix]: Use Buffer object for NodeJs environment

### DIFF
--- a/src/helpers/ipfs.ts
+++ b/src/helpers/ipfs.ts
@@ -12,7 +12,7 @@ export const DEFAULT_IPFS_GATEWAY = "https://ipfs.ternoa.dev/api/v0/add"
  * @param apiKey        API Key to validate the upload on the IPFS gateway.
  * @returns             A formatted object datas with name, hash, size and type.
  */
-export const ipfsFileUpload = async (file: File, ipfsGateway?: string, apiKey?: string) => {
+export const ipfsFileUpload = async (file: File | Buffer, ipfsGateway?: string, apiKey?: string) => {
   const formData = new FormData()
   formData.append(`file`, file)
   const headers = apiKey ? { apiKey: apiKey } : undefined

--- a/src/nft/utils.ts
+++ b/src/nft/utils.ts
@@ -28,8 +28,16 @@ export const nftIpfsUpload = async (data: INFTMetadata, ipfsGateway?: string, ap
       },
     },
   }
-  const finalBlob = new Blob([JSON.stringify(nftMetadata)], { type: "application/json" })
-  const finalFile = new File([finalBlob], "nft metadata")
+  const isBrowser = typeof Blob === 'function' && typeof File === 'function'
+  let finalBlob
+  let finalFile
+  if (isBrowser) {
+      finalBlob = new Blob([JSON.stringify(nftMetadata)], { type: "application/json" })
+      finalFile = new File([finalBlob], "nft metadata")
+  } else {
+      finalBlob = new Uint8Array(Buffer.from(JSON.stringify(nftMetadata)))
+      finalFile = Buffer.from(finalBlob)
+  }
   return await ipfsFileUpload(finalFile, ipfsGateway, apiKey)
 }
 
@@ -52,7 +60,15 @@ export const collectionIpfsUpload = async (data: ICollectionMetadata, ipfsGatewa
     profileImage: profileFileHash,
     bannerImage: bannerFileHash,
   }
-  const finalBlob = new Blob([JSON.stringify(collectionMetadata)], { type: "application/json" })
-  const finalFile = new File([finalBlob], "collection metadata")
+  const isBrowser = typeof Blob === 'function' && typeof File === 'function'
+  let finalBlob
+  let finalFile
+  if (isBrowser) {
+      finalBlob = new Blob([JSON.stringify(collectionMetadata)], { type: "application/json" })
+      finalFile = new File([finalBlob], "collection metadata")
+  } else {
+      finalBlob = new Uint8Array(Buffer.from(JSON.stringify(collectionMetadata)))
+      finalFile = Buffer.from(finalBlob)
+  }
   return await ipfsFileUpload(finalFile, ipfsGateway, apiKey)
 }


### PR DESCRIPTION
## Description

I could found a solution by using a Buffer object when we try to use "nftIpfsUpload" and "collectionIpfsUpload" utils in NodeJs.

What I do :
- I check if the File & Blob objects are available, if not I assume we are in a NodeJs environment. 
- If in a browser environment, I'm still using File & Blob and pass File object to "ipfsFileUpload" helper.
- If in a NodeJs environment, I use Uint8Array instead of Blob and Buffer instead of File objects.

The "isBrowser" variable could rely on something else and can also be externalised in the helpers part. Of course, I'm still open to discuss which solution you prefer.

## Related Issue
https://github.com/capsule-corp-ternoa/ternoa-js/discussions/111

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
